### PR TITLE
If a relationship is not set, return null from `follow()`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.4.0 (????-??-??)
+0.4.0 (2025-04-16)
 ------------------
 
 * `.follow()` will now return null for a relationship that's not found.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.4.0 (????-??-??)
+------------------
+
+* `.follow()` will now return null for a relationship that's not found.
+
+
 0.3.1 (2025-04-15)
 ------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sprout-family/hateoas",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sprout-family/hateoas",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@curveball/links": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sprout-family/hateoas",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Description goes here",
   "type": "module",
   "exports": "./dist/index.js",

--- a/src/hal.ts
+++ b/src/hal.ts
@@ -1,12 +1,13 @@
 import { State } from './state.js';
 import { HalResource, HalLink } from 'hal-types';
 import { Link } from '@curveball/links';
+import { StateSchema } from './types.js';
 
 type HalOptions = {
   defaultUri?: string;
 };
 
-export function stateToHal(state: State, options: HalOptions = {}): HalResource {
+export function stateToHal<T extends StateSchema>(state: State<T>, options: HalOptions = {}): HalResource {
 
   const links: Link[] = [];
   for(const link of state.links) {
@@ -14,6 +15,9 @@ export function stateToHal(state: State, options: HalOptions = {}): HalResource 
   }
   for(const [relType, relationships] of Object.entries(state.relationships)) {
 
+    if (!relationships) {
+      continue;
+    }
     for(const relationship of Array.isArray(relationships) ? relationships : [relationships] ) {
 
       if (!relationship.uri) {

--- a/src/siren.ts
+++ b/src/siren.ts
@@ -1,4 +1,5 @@
 import { State } from './state.js';
+import { StateSchema } from './types.js';
 
 type SirenOptions = {
   defaultUri?: string;
@@ -23,7 +24,7 @@ type SirenLink = {
 
 type SirenSubEntity = SirenEntity & { rel: string[] };
 
-export function stateToSiren(state: State, options: SirenOptions = {}): SirenEntity {
+export function stateToSiren<T extends StateSchema>(state: State<T>, options: SirenOptions = {}): SirenEntity {
 
   const links: SirenLink[] = [];
   const entities: SirenLink[] = [];
@@ -48,6 +49,9 @@ export function stateToSiren(state: State, options: SirenOptions = {}): SirenEnt
 
   for(const [rel, relationships] of Object.entries(state.relationships)) {
 
+    if (!relationships) {
+      continue;
+    }
     for(const relationship of Array.isArray(relationships) ? relationships : [relationships]) {
 
       if (!relationship.uri) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,9 @@ export interface StateSchema {
 
 /**
  * This utility schema represents the usual shape of a collection.
+ *
+ * Using it is completely optional, but it's an exampel of how schemas
+ * might be combined and composed.
  */
 export interface CollectionOf<T extends StateSchema> extends StateSchema {
 

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -38,7 +38,7 @@ describe('State Schemas', () => {
     });
 
     const article = new State<ArticleSchema>({
-      uri: '/author/2',
+      uri: '/article/2',
       data: {
         title: 'Hello world',
         body: 'SUPPP',
@@ -68,5 +68,64 @@ describe('State Schemas', () => {
 
   });
 
+  it('The type system should error when accessing an optional relationship', () => {
+
+    const author = new State<AuthorSchema>({
+      uri: '/author/1',
+      data: {
+        name: 'Evert',
+        website: 'https://evertpot.com/',
+      },
+    });
+    const article = new State<ArticleSchema>({
+      uri: '/article/2',
+      data: {
+        title: 'Hello world',
+        body: 'SUPPP',
+      },
+      relationships: {
+        author,
+        category: null
+      }
+    });
+    // We're not executing this code, just testing the type system.
+    () => {
+
+      // @ts-expect-error category is optional, so we should get an error.
+      const category = article.follow('category').data.name;
+      console.log(category);;
+
+    };
+
+  });
+  it('The type system should not error when accessing a required relationship', () => {
+
+    const author = new State<AuthorSchema>({
+      uri: '/author/1',
+      data: {
+        name: 'Evert',
+        website: 'https://evertpot.com/',
+      },
+    });
+    const article = new State<ArticleSchema>({
+      uri: '/article/2',
+      data: {
+        title: 'Hello world',
+        body: 'SUPPP',
+      },
+      relationships: {
+        author,
+        category: null
+      }
+    });
+    // We're not executing this code, just testing the type system.
+    () => {
+
+      const author = article.follow('author').data.name;
+      console.log(author);
+
+    };
+
+  });
 
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -89,11 +89,12 @@ describe('State Schemas', () => {
       }
     });
     // We're not executing this code, just testing the type system.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     () => {
 
       // @ts-expect-error category is optional, so we should get an error.
       const category = article.follow('category').data.name;
-      console.log(category);;
+      console.info(category);;
 
     };
 
@@ -119,10 +120,11 @@ describe('State Schemas', () => {
       }
     });
     // We're not executing this code, just testing the type system.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     () => {
 
       const author = article.follow('author').data.name;
-      console.log(author);
+      console.info(author);
 
     };
 


### PR DESCRIPTION
When chaining follows this is much less painful to deal with. `follow()`
now may return null, and the types only have a 'null' response type
if the relationship was optional.
